### PR TITLE
added CI configs for Travis and Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,18 @@
+image: docker:git
+services:
+  - docker:dind
+
+variables:
+  UPSTREAM_WORKSPACE: file
+  ROSINSTALL_FILENAME: snp_demo_deps.rosinstall
+  ROSDEP_SKIP_KEYS: "pilz_modbus pilz_sto_modbus_adapter pilz_trajectory_generation psir_moveit_config psir_description"
+  BEFORE_SCRIPT: "wget -q https://download.ensenso.com/s/ensensosdk/download?files=ensenso-sdk-2.2.65-x64.deb -O /tmp/ensenso.deb && dpkg -i /tmp/ensenso.deb"
+  DOCKER_RUN_OPTS: "-e ENSENSO_INSTALL=/opt/ensenso"
+  ADDITIONAL_DEBS: "pkg-config"
+  CATKIN_CONFIG: "--no-install"
+
+before_script:
+  - apk add --update bash coreutils tar
+  - git clone --depth=1 https://github.com/ros-industrial/industrial_ci .industrial_ci
+kinetic:
+  script: .industrial_ci/gitlab.sh ROS_DISTRO=kinetic ROS_REPO=ros

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+dist: trusty
+language: generic
+
+env:
+  global:
+    - UPSTREAM_WORKSPACE=file
+    - ROSINSTALL_FILENAME=snp_demo_deps.rosinstall
+    - ROSDEP_SKIP_KEYS="pilz_modbus pilz_sto_modbus_adapter pilz_trajectory_generation psir_moveit_config psir_description"
+    - BEFORE_SCRIPT="wget -q https://download.ensenso.com/s/ensensosdk/download?files=ensenso-sdk-2.2.65-x64.deb -O /tmp/ensenso.deb && dpkg -i /tmp/ensenso.deb"
+    - DOCKER_RUN_OPTS="-e ENSENSO_INSTALL=/opt/ensenso"
+    - ADDITIONAL_DEBS="pkg-config"
+    - CATKIN_CONFIG="--no-install"
+  matrix:
+    - ROS_DISTRO=kinetic ROS_REPO=ros
+
+install:
+  - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - .ci_config/travis.sh


### PR DESCRIPTION
Has been tested on our Gitlab CI server and with `run_travis` (https://github.com/ros-industrial/industrial_ci/pull/265).
(Travis is not yet enabled for this repository.)