### PR TITLE
remove dublicate controller_spawner for prbt_real

### DIFF
--- a/snp_prbt_bringup/launch/hardware_bringup.launch
+++ b/snp_prbt_bringup/launch/hardware_bringup.launch
@@ -4,19 +4,11 @@
   <arg name="sim_robot" default="false"/>
   <arg name="pipeline" default="command_planner"/>
   <arg name="robot_name" default="prbt"/>
-  <arg name="controller_group" default="manipulator"/>
   <arg name="robot_description" value="$(arg robot_name)_description"/>
   <arg name="urdf_file" default="$(find snp_prbt_description)/urdf/snp_prbt_demo.urdf.xacro"/>
 
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
   <param name="robot_description" type="str" command="$(find xacro)/xacro --inorder '$(arg urdf_file)' sim:=$(arg sim_robot)"/>
-
-  <!-- Controllers -->
-  <group ns="$(arg robot_name)">
-    <rosparam command="load" file="$(find prbt_support)/config/$(arg controller_group)_controller.yaml" />
-    <node name="controller_spawner" pkg="controller_manager" type="spawner"
-          args="$(arg controller_group)_joint_trajectory_controller $(arg controller_group)_joint_state_controller" />
-  </group>
 
   <!-- Robot -->
   <group if="$(arg sim_robot)">

--- a/snp_prbt_bringup/launch/prbt_gazebo.launch
+++ b/snp_prbt_bringup/launch/prbt_gazebo.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <launch>
 
+  <arg name="controller_group" default="manipulator"/>
   <arg name="robot_name" default="prbt" />
   <arg name="paused" default="true"/>
   <arg name="gui" default="false"/>
@@ -20,6 +21,13 @@
     -J $(arg robot_name)_joint_5 -1.0
     -J $(arg robot_name)_joint_6 -1.5
     "/>
+
+  <!-- Controllers -->
+  <group ns="$(arg robot_name)">
+    <rosparam command="load" file="$(find prbt_support)/config/$(arg controller_group)_controller.yaml" />
+    <node name="controller_spawner" pkg="controller_manager" type="spawner"
+          args="$(arg controller_group)_joint_trajectory_controller $(arg controller_group)_joint_state_controller" />
+  </group>
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 


### PR DESCRIPTION
`<include file="$(find prbt_support)/launch/robot.launch" >` in [prbt_real.launch](https://github.com/rosin-project/automatica18_scan_and_plan_demo/blob/master/snp_prbt_bringup/launch/prbt_real.launch) already includes the `controller_spawner`, which one can see here in [robot.launch](https://github.com/PilzDE/pilz_robots/blob/kinetic-devel/prbt_support/launch/robot.launch).